### PR TITLE
GTK cpufreq: fix label position on horizontal panels

### DIFF
--- a/cpufreq/src/cpufreq-applet.c
+++ b/cpufreq/src/cpufreq-applet.c
@@ -953,6 +953,23 @@ cpufreq_applet_refresh (CPUFreqApplet *applet)
         }
 
 	if (horizontal) {
+#if GTK_CHECK_VERSION (3, 0, 0)
+		applet->labels_box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
+		if ((label_size + pixmap_size) <= panel_size)
+			applet->box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 2);
+		else
+			applet->box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
+	} else {
+                if (total_size <= panel_size) {
+                        applet->box = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
+                        applet->labels_box  = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
+                } else if ((label_size + unit_label_size) <= (panel_size - size_step)) {
+                        applet->box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 2);
+                        applet->labels_box  = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 2);
+                } else {
+                        applet->box = gtk_box_new (GTK_ORIENTATION_VERTICAL, 2);
+                        applet->labels_box  = gtk_box_new (GTK_ORIENTATION_VERTICAL, 2);
+#else
 		applet->labels_box = gtk_hbox_new (FALSE, 2);
 		if ((label_size + pixmap_size) <= panel_size)
 			applet->box = gtk_vbox_new (FALSE, 2);
@@ -968,6 +985,7 @@ cpufreq_applet_refresh (CPUFreqApplet *applet)
                 } else {
                         applet->box = gtk_vbox_new (FALSE, 2);
                         applet->labels_box  = gtk_vbox_new (FALSE, 2);
+#endif
                 }
 	}
 


### PR DESCRIPTION
The issue was caused by using deprecated widgets and defines
for orientation with GTK3.
#define gtk_vbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_VERTICAL,Y)
#define gtk_hbox_new(X,Y) gtk_box_new(GTK_ORIENTATION_HORIZONTAL,Y)
Deprecated gtk_[h/v]box_new don't use them.