### PR TITLE
cpufreq: remove unused argument "parent"

### DIFF
--- a/cpufreq/src/cpufreq-popup.c
+++ b/cpufreq/src/cpufreq-popup.c
@@ -188,7 +188,6 @@ cpufreq_popup_frequencies_menu_activate (GtkAction    *action,
 	const gchar     *name;
 	guint            cpu;
 	guint            freq;
-	guint32          parent;
 
 	if (!gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action)))
 		return;
@@ -198,12 +197,8 @@ cpufreq_popup_frequencies_menu_activate (GtkAction    *action,
 	cpu = cpufreq_monitor_get_cpu (popup->priv->monitor);
 	name = gtk_action_get_name (action);
 	freq = (guint) atoi (name + strlen ("Frequency"));
-	/*stop applet from turning transparent when menu clicked in gtk3.16 or later */
-#if !GTK_CHECK_VERSION (3, 0, 0)
-	parent = GDK_WINDOW_XID (gtk_widget_get_window (popup->priv->parent));
-#endif
 
-	cpufreq_selector_set_frequency_async (selector, cpu, freq, parent);
+	cpufreq_selector_set_frequency_async (selector, cpu, freq);
 }
 
 static void
@@ -214,7 +209,6 @@ cpufreq_popup_governors_menu_activate (GtkAction    *action,
 	const gchar     *name;
 	guint            cpu;
 	const gchar     *governor;
-	guint32          parent;
 
 	if (!gtk_toggle_action_get_active (GTK_TOGGLE_ACTION (action)))
 		return;
@@ -224,11 +218,8 @@ cpufreq_popup_governors_menu_activate (GtkAction    *action,
 	cpu = cpufreq_monitor_get_cpu (popup->priv->monitor);
 	name = gtk_action_get_name (action);
 	governor = name + strlen ("Governor");
-	/*stop applet from turning transparent when menu clicked in gtk3.16 or later */
-#if !GTK_CHECK_VERSION (3, 0, 0)
-	parent = GDK_WINDOW_XID (gtk_widget_get_window (popup->priv->parent));
-#endif
-	cpufreq_selector_set_governor_async (selector, cpu, governor, parent);
+
+	cpufreq_selector_set_governor_async (selector, cpu, governor);
 }
 
 static void

--- a/cpufreq/src/cpufreq-selector.c
+++ b/cpufreq/src/cpufreq-selector.c
@@ -171,8 +171,7 @@ selector_set_frequency_async (SelectorAsyncData *data)
 void
 cpufreq_selector_set_frequency_async (CPUFreqSelector *selector,
 				      guint            cpu,
-				      guint            frequency,
-				      guint32          parent)
+				      guint            frequency)
 {
 	SelectorAsyncData *data;
 
@@ -182,7 +181,6 @@ cpufreq_selector_set_frequency_async (CPUFreqSelector *selector,
 	data->call = FREQUENCY;
 	data->cpu = cpu;
 	data->frequency = frequency;
-	data->parent_xid = parent;
 
 	selector_set_frequency_async (data);
 }
@@ -220,8 +218,7 @@ selector_set_governor_async (SelectorAsyncData *data)
 void
 cpufreq_selector_set_governor_async (CPUFreqSelector *selector,
 				     guint            cpu,
-				     const gchar     *governor,
-				     guint32          parent)
+				     const gchar     *governor)
 {
 	SelectorAsyncData *data;
 
@@ -231,7 +228,6 @@ cpufreq_selector_set_governor_async (CPUFreqSelector *selector,
 	data->call = GOVERNOR;
 	data->cpu = cpu;
 	data->governor = g_strdup (governor);
-	data->parent_xid = parent;
 
 	selector_set_governor_async (data);
 }
@@ -264,8 +260,7 @@ cpufreq_selector_run_command (CPUFreqSelector *selector,
 void
 cpufreq_selector_set_frequency_async (CPUFreqSelector *selector,
 				      guint            cpu,
-				      guint            frequency,
-				      guint32          parent)
+				      guint            frequency)
 {
 	gchar *args;
 
@@ -277,8 +272,7 @@ cpufreq_selector_set_frequency_async (CPUFreqSelector *selector,
 void
 cpufreq_selector_set_governor_async (CPUFreqSelector *selector,
 				     guint            cpu,
-				     const gchar     *governor,
-				     guint32          parent)
+				     const gchar     *governor)
 {
 	gchar *args;
 

--- a/cpufreq/src/cpufreq-selector.h
+++ b/cpufreq/src/cpufreq-selector.h
@@ -39,12 +39,10 @@ GType            cpufreq_selector_get_type            (void) G_GNUC_CONST;
 CPUFreqSelector *cpufreq_selector_get_default         (void);
 void             cpufreq_selector_set_frequency_async (CPUFreqSelector *selector,
 						       guint            cpu,
-						       guint            frequency,
-						       guint32          parent);
+						       guint            frequency);
 void             cpufreq_selector_set_governor_async  (CPUFreqSelector *selector,
 						       guint            cpu,
-						       const gchar     *governor,
-						       guint32          parent);
+						       const gchar     *governor);
 	
 G_END_DECLS
 


### PR DESCRIPTION
remove unused argument "parent" in cpufreq_selector_set_xxx_async functions